### PR TITLE
Added support for Alternate Stylesheets

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function gulpSriPhp(opts) {
 }
 
 function processStylesheets(orig) {
-  var regex = /<link.*?rel=['"]{0,1}stylesheet['"]{0,1}[^>]*>/gmi;
+  var regex = /<link.*?rel=['"]{0,1}(alternate )?stylesheet['"]{0,1}[^>]*>/gmi;
   var cont = orig;
   var res = null;
   while((res = regex.exec(orig))) {


### PR DESCRIPTION
Alternative Stylesheets may be offered by a website to allow users to customize the browsing experience or to enhance accessibility. They are susceptible to the same attack vectors as preferred or persistent stylesheets and should therefore also make use of SRI hashes.

This change merely enables the regular expression which identifies stylesheet LINK tags to recognize alternative (alternate) stylesheets.